### PR TITLE
Instalar plugin jacoco

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,92 @@
 # listademercados
 Web service que retorna um json de lista de produtos de mercados
+
+[![Badge](https://img.shields.io/badge/App-ListaDeMercados-%237159c1?style=for-the-badge&logo=ghost)](https://github.com/accountToLearn/listademercados)
+
+#### Status do projeto
+	🚧  Java 🚀 Em construção...  🚧
+	
+Tabela de conteúdos
+=================== 
+* [Item1](item1)
+* [Item2](item2)
+* [Item3](item3)
+
+# Escopo e objetivo
+*Organização de código de referência para desenvolvimento de software em Java*. 
+
+Esta organização inclui um conjunto "completo" de ferramentas, já configuradas, para o desenvolvimento
+empregando Java.
+
+O projeto inclui:<br>
+- [x] uma biblioteca formada por um único método que identifica o dia da semana para uma data fornecida; 
+- [x] uma aplicação que oferece tal funcionalidade via linha de comandos e (c) uma RESTFul API ambas para acesso à funcionalidade da biblioteca.
+
+> Objetivo: ilustrar uma organização de código em Java usando
+"boas práticas" para inspirar projetos reais.
+
+## Pré-requisitos
+- `mvn --version` 
+- `java -version`  
+ > Você deverá ver a indicação da versão do Maven instalada e a versão do JDK, dentre outras. Observe que o JDK é obrigatório, assim como a definição das variáveis de ambientes **JAVA_HOME** e **M2_HOME**
+
+## Iniciando...
+- `git clone https://github.com/accountToLearn/listademercados.git`
+
+Agora você poderá executar os vários comandos abaixo.
+
+## Limpar, compilar, executar testes de unidade e cobertura
+- `mvn clean`<br>
+remove diretório _target_
+
+- `mvn compile`<br>
+compila o projeto, deposita resultados no diretório _target_
+
+- `mvn test`<br>
+executa todos os testes do projeto. Para executar apenas parte dos testes, por exemplo,
+aqueles contidos em uma dada classe execute `mvn -Dtest=NomeDaClasseTest test`. Observe
+que o sufixo do nome da classe de teste é `Test` (padrão recomendado). Para executar um
+único teste `mvn -Dtest=NomeDaClasseTest#nomeDoMetodo test`. Produz relatório de
+cobertura em _target/site/jacoco/index.html_ além de verificar se limite mínimo
+de cobertura, conforme configurado, é satisfeito.
+
+## Empacotando o projeto
+- `mvn package`<br>
+gera arquivo listademercado-VERSÃO.war_ no diretório _target_.
+
+## Análise estática
+Trata-se da análise do código sem que seja executado. Esta análise produz
+uma "noção de quão bom" está o código sob alguns aspecto e, em consequência, 
+permite orientar eventuais ações de melhoria. Fique atento, "sair 
+bem" na análise estática não significa que "agrada usuários". A análise 
+estática observa o código. 
+
+- **JACOCO**
+    - `mvn jacoco:check`<br>
+  Faz uma checagem na cobertura dos testes unitários.<br>
+  Falha, se não for respeitado uma cobertura miníma de 80% de todo código e 50% das classes.
+    - `mvn jacoco:prepare-agent`<br>
+  Prepara uma propriedade apontando para o agente de tempo de execução JaCoCo.
+    - `mvn jacoco:report`<br>
+  Gera relatório em *target/site/jacoco/index.html*.<br>
+  Relatório de cobertura dos testes unitários do projeto.
+  
+### Tecnologias utilizadas
+- [![Java 14](https://img.shields.io/badge/Java-14-1f425f.svg)](https://docs.oracle.com/en/java/javase/14/)
+- [![Maven](https://img.shields.io/badge/Maven-1f425f.svg)](https://maven.apache.org/guides/index.html)
+
+### Autor
+---
+
+<a href="">
+ <img style="border-radius: 50%;" src="" width="100px;" alt=""/>
+ <br />
+ <sub><b>Account To Learn</b></sub></a> <a href="" title="Rocketseat">🚀</a>
+
+
+Feito com ❤️ por Account To Learn 👋🏽 Entre em contato!
+
+[![Twitter Badge](https://img.shields.io/badge/-@accountToLearn-1ca0f1?style=flat-square&labelColor=1ca0f1&logo=twitter&logoColor=white&link=https://twitter.com/accountToLearn)](https://twitter.com/accountToLearn) [![Linkedin Badge](https://img.shields.io/badge/-accountToLearn-blue?style=flat-square&logo=Linkedin&logoColor=white&link=https://www.linkedin.com/in/accountToLearn/)](https://www.linkedin.com/in/accountToLearn/) 
+[![Gmail Badge](https://img.shields.io/badge/-listademercados@hotmail.com-c14438?style=flat-square&logo=Hotmail&logoColor=white&link=mailto:listademercados@hotmail.com)](mailto:listademercados@hotmail.com)
+
+     

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ de cobertura, conforme configurado, é satisfeito.
 
 ## Empacotando o projeto
 - `mvn package`<br>
-gera arquivo listademercado-VERSÃO.war_ no diretório _target_.
+gera arquivo _listademercado-VERSÃO.war_ no diretório _target_.
 
 ## Análise estática
 Trata-se da análise do código sem que seja executado. Esta análise produz

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	<description>Web service que retorna um json de lista de produtos de mercados</description>
 
 	<properties>
-		<java.version>15</java.version>
+		<java.version>14</java.version>
 	</properties>
 
 	<dependencies>
@@ -36,14 +36,71 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-
+	
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.6</version>
+				<executions>
+					<execution>
+						<id>default-jacoco-check</id>
+	                    <phase>test</phase>
+	                    <goals>
+	                        <goal>check</goal>
+	                    </goals>
+	                    <configuration>
+	                        <rules>
+	                            <rule>
+	                                <element>BUNDLE</element>
+	                                <limits>
+	                                    <limit>
+	                                        <counter>INSTRUCTION</counter>
+	                                        <value>COVEREDRATIO</value>
+	                                        <minimum>0.80</minimum>
+	                                    </limit>
+	                                    <limit>
+	                                        <counter>CLASS</counter>
+	                                        <value>MISSEDCOUNT</value>
+	                                        <minimum>0</minimum>
+	                                    </limit>
+	                                </limits>
+	                            </rule>
+							  	<rule>
+							    	<element>CLASS</element>
+							    	<excludes>
+							      		<exclude>*Test</exclude>
+							    	</excludes>
+							    	<limits>
+							      		<limit>
+							        		<counter>LINE</counter>
+							        		<value>COVEREDRATIO</value>
+							        		<minimum>50%</minimum>
+							      		</limit>
+							    	</limits>
+							  	</rule>
+	                        </rules>
+	                    </configuration>
+					</execution>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
-
 </project>


### PR DESCRIPTION
# Finalização da configuração do plugin jacoco do maven
- **JACOCO**
    - `mvn jacoco:check`<br>
  Faz uma checagem na cobertura dos testes unitários.<br>
  Falha, se não for respeitado uma cobertura miníma de 80% de todo código e 50% das classes.
    - `mvn jacoco:prepare-agent`<br>
  Prepara uma propriedade apontando para o agente de tempo de execução JaCoCo.
    - `mvn jacoco:report`<br>
  Gera relatório em *target/site/jacoco/index.html*.<br>
  Relatório de cobertura dos testes unitários do projeto.